### PR TITLE
Bug fixes and improvements

### DIFF
--- a/src/scopedQuerySelectorShim.js
+++ b/src/scopedQuerySelectorShim.js
@@ -13,9 +13,9 @@
     container.querySelectorAll(':scope *');
   }
   catch (e) {
-
-    // Match usage of scope
-    var scopeRE = /\s*:scope\s*/gi;
+    var rxTest = /(?:^|,)\s*:scope\s+/,
+      rxStart = /^\s*:scope\s+/i,
+      rxOthers = /,\s*:scope\s+/gi;
 
     // Overrides
     function overrideNodeMethod(prototype, methodName) {
@@ -24,12 +24,12 @@
 
       // Override the method
       prototype[methodName] = function(query) {
-        var nodeList, parentNode, frag,
+        var nodeList, parentNode, frag, idSelector,
           gaveId = false,
           gaveContainer = false,
           parentIsFragment = false;
 
-        if (query.match(scopeRE)) {
+        if (rxTest.test(query)) {
 
           if (!this.parentNode) {
             // Add to temporary container
@@ -52,7 +52,8 @@
           }
 
           // replace :scope with ID selector
-          query = query.replace(scopeRE, '#' + this.id + ' ');
+          idSelector = '#' + this.id + ' ';
+          query = query.replace(rxStart, idSelector).replace(rxOthers, ', ' + idSelector);
 
           // Find elements against parent node
           nodeList = oldMethod.call(parentNode, query);

--- a/test/testShim.js
+++ b/test/testShim.js
@@ -14,21 +14,44 @@ describe('scopedQuerySelectorShim', function() {
     return node;
   }
 
+  function makeNodeAndAddToFragment(html) {
+    var frag, node;
+    frag = document.createDocumentFragment();
+    node = makeNode(html);
+    frag.appendChild(node);
+    return node;
+  }
+
   function testChildNode(node) {
-    expect(node.innerHTML).to.equal('Child');
+    expect(node.innerHTML).toBe('Child');
   }
 
   function testChildNodeList(nodeList) {
-    expect(nodeList.length).to.equal(1);
+    expect(nodeList.length).toBe(1);
     testChildNode(nodeList[0]);
+  }
+  
+  function testComplexNodeList(nodeList) {
+    testGrandChildNode(nodeList[0]);
+    testGrandChildNode1(nodeList[1]);
+    testGrandChildNode2(nodeList[2]);
+    testGrandChildNode3(nodeList[3]);
   }
 
   function testGrandChildNode(node) {
-    expect(node.innerHTML).to.equal('Grandchild 1');
+    expect(node.innerHTML).toBe('Grandchild 1');
   }
 
   function testGrandChildNode1(node) {
-    expect(node.innerHTML).to.equal('Grandchild 2');
+    expect(node.innerHTML).toBe('Grandchild 2');
+  }
+
+  function testGrandChildNode2(node) {
+    expect(node.innerHTML).toBe('Grandchild 3');
+  }
+
+  function testGrandChildNode3(node) {
+    expect(node.innerHTML).toBe('Grandchild 4');
   }
 
   function testGrandChildNodeList(nodeList) {
@@ -45,13 +68,24 @@ describe('scopedQuerySelectorShim', function() {
     <div>\
       <header>Grandchild</header>\
     </div>\
-  </div>';
+  <div>';
 
   var listHTML = '<div>\
     <ul>\
       <li>Grandchild 1</li>\
       <li>Grandchild 2</li>\
     </ul>\
+  </div>';
+
+  var complexHTML = '<div>\
+    <ul>\
+      <li>Grandchild 1</li>\
+      <li>Grandchild 2</li>\
+    </ul>\
+    <ol>\
+      <li>Grandchild 3</li>\
+      <li>Grandchild 4</li>\
+    </ol>\
   </div>';
 
   describe('when nodes are in the DOM', function() {
@@ -63,6 +97,11 @@ describe('scopedQuerySelectorShim', function() {
     it('should find grandchild nodes', function() {
       testGrandChildNode(makeNodeAndAddToDOM(listHTML).querySelector(':scope > ul > li'));
       testGrandChildNodeList(makeNodeAndAddToDOM(listHTML).querySelectorAll(':scope > ul > li'));
+    });
+
+    it('should handle complex queries', function() {
+      testGrandChildNode(makeNodeAndAddToDOM(complexHTML).querySelector(':scope > ul > li, :scope > ol > li'));
+      testComplexNodeList(makeNodeAndAddToDOM(complexHTML).querySelectorAll(':scope > ul > li, :scope > ol > li'));
     });
   });
 
@@ -76,30 +115,52 @@ describe('scopedQuerySelectorShim', function() {
       testGrandChildNode(makeNode(listHTML).querySelector(':scope > ul > li'));
       testGrandChildNodeList(makeNode(listHTML).querySelectorAll(':scope > ul > li'));
     });
+
+    it('should handle complex queries', function() {
+      testGrandChildNode(makeNode(complexHTML).querySelector(':scope > ul > li, :scope > ol > li'));
+      testComplexNodeList(makeNode(complexHTML).querySelectorAll(':scope > ul > li, :scope > ol > li'));
+    });
+  });
+
+  describe('when nodes are in a document fragment', function() {
+    it('should find child nodes', function() {
+      testChildNode(makeNodeAndAddToFragment(childHTML).querySelector(':scope > header'));
+      testChildNodeList(makeNodeAndAddToFragment(childHTML).querySelectorAll(':scope > header'));
+    });
+
+    it('should find grandchild nodes', function() {
+      testGrandChildNode(makeNodeAndAddToFragment(listHTML).querySelector(':scope > ul > li'));
+      testGrandChildNodeList(makeNodeAndAddToFragment(listHTML).querySelectorAll(':scope > ul > li'));
+    });
+
+    it('should handle complex queries', function() {
+      testGrandChildNode(makeNodeAndAddToFragment(complexHTML).querySelector(':scope > ul > li, :scope > ol > li'));
+      testComplexNodeList(makeNodeAndAddToFragment(complexHTML).querySelectorAll(':scope > ul > li, :scope > ol > li'));
+    });
   });
 
   describe('when temporary containers and IDs are used', function() {
     it('should not leave nodes in temporary container', function() {
       var node = makeNode(childHTML);
-      expect(node.parentNode).to.be.null;
+      expect(node.parentNode).toBe(null);
       node.querySelectorAll(':scope > header');
-      expect(node.parentNode).to.be.null;
+      expect(node.parentNode).toBe(null);
     });
 
     it('should not leave temporary IDs', function() {
       var node = makeNode(childHTML);
-      expect(node.id).to.equal('');
+      expect(node.id).toBe('');
       node.querySelectorAll(':scope > header');
-      expect(node.id).to.equal('');
+      expect(node.id).toBe('');
     });
   });
 
   describe('when nodes have IDs', function() {
     it('should not overwrite existing IDs', function() {
       var node = makeNode(idHTML);
-      expect(node.id).to.equal('myDiv');
+      expect(node.id).toBe('myDiv');
       node.querySelectorAll(':scope > header');
-      expect(node.id).to.equal('myDiv');
+      expect(node.id).toBe('myDiv');
     });
   });
 });


### PR DESCRIPTION
Improved :scope replacement by fixing regular expression and selector replacement.
Declared a variable as local that was identifying as global.
Enabled the ability to run query selector when the parent node is a document fragment.