### PR TITLE
Making JS TypeScript friendly

### DIFF
--- a/src/scopedQuerySelectorShim.js
+++ b/src/scopedQuerySelectorShim.js
@@ -37,7 +37,7 @@
             gaveContainer = true;
           }
 
-          parentNode = this.parentNode;
+          var parentNode = this.parentNode;
 
           if (!this.id) {
             // Give temporary ID


### PR DESCRIPTION
TypeScript won't compile the source as is, needs a slight modification. Is that an advantage to not using the var keyword? It doesn't seem like `parentNode` needs to look to or be assigned to the global scope.

```bash
Using tsc v1.4.1
error TS2304: Cannot find name 'parentNode'.
```