### PR TITLE
retain copyright notice

### DIFF
--- a/src/scopedQuerySelectorShim.js
+++ b/src/scopedQuerySelectorShim.js
@@ -1,3 +1,8 @@
+/*
+Copyright (c) 2014, Lawrence Davis
+All rights reserved.
+https://github.com/lazd/scopedQuerySelectorShim
+*/
 (function() {
   if (!HTMLElement.prototype.querySelectorAll) {
     throw new Error('rootedQuerySelectorAll: This polyfill can only be used with browsers that support querySelectorAll');


### PR DESCRIPTION
Correct me if I'm wrong but it seems like `scopedQuerySelectorShim.js` disobeys it's own `LICENSE`. The README says to simply include the `scopedQuerySelectorShim.js` file, but it that is all you do you disobey the `LICENSE`.