### PR TITLE
Distribute Grunt Workflow

### DIFF
--- a/dist/scopedQuerySelectorShim.js
+++ b/dist/scopedQuerySelectorShim.js
@@ -1,0 +1,65 @@
+/* scopeQuerySelectorShim.js
+*
+* Copyright (C) 2015 Larry Davis
+* All rights reserved.
+*
+* This software may be modified and distributed under the terms
+* of the BSD license.  See the LICENSE file for details.
+*/
+(function() {
+    if (!HTMLElement.prototype.querySelectorAll) {
+        throw new Error("rootedQuerySelectorAll: This polyfill can only be used with browsers that support querySelectorAll");
+    }
+    // A temporary element to query against for elements not currently in the DOM
+    // We'll also use this element to test for :scope support
+    var container = document.createElement("div");
+    // Check if the browser supports :scope
+    try {
+        // Browser supports :scope, do nothing
+        container.querySelectorAll(":scope *");
+    } catch (e) {
+        // Match usage of scope
+        var scopeRE = /^\s*:scope/gi;
+        // Overrides
+        function overrideNodeMethod(prototype, methodName) {
+            // Store the old method for use later
+            var oldMethod = prototype[methodName];
+            // Override the method
+            prototype[methodName] = function(query) {
+                var nodeList, gaveId = false, gaveContainer = false;
+                if (query.match(scopeRE)) {
+                    // Remove :scope
+                    query = query.replace(scopeRE, "");
+                    if (!this.parentNode) {
+                        // Add to temporary container
+                        container.appendChild(this);
+                        gaveContainer = true;
+                    }
+                    parentNode = this.parentNode;
+                    if (!this.id) {
+                        // Give temporary ID
+                        this.id = "rootedQuerySelector_id_" + new Date().getTime();
+                        gaveId = true;
+                    }
+                    // Find elements against parent node
+                    nodeList = oldMethod.call(parentNode, "#" + this.id + " " + query);
+                    // Reset the ID
+                    if (gaveId) {
+                        this.id = "";
+                    }
+                    // Remove from temporary container
+                    if (gaveContainer) {
+                        container.removeChild(this);
+                    }
+                    return nodeList;
+                } else {
+                    // No immediate child selector used
+                    return oldMethod.call(this, query);
+                }
+            };
+        }
+        // Browser doesn't support :scope, add polyfill
+        overrideNodeMethod(HTMLElement.prototype, "querySelector");
+        overrideNodeMethod(HTMLElement.prototype, "querySelectorAll");
+    }
+})();

--- a/dist/scopedQuerySelectorShim.min.js
+++ b/dist/scopedQuerySelectorShim.min.js
@@ -1,0 +1,9 @@
+/* scopeQuerySelectorShim.js
+*
+* Copyright (C) 2015 Larry Davis
+* All rights reserved.
+*
+* This software may be modified and distributed under the terms
+* of the BSD license.  See the LICENSE file for details.
+*/
+!function(){function a(a,c){var e=a[c];a[c]=function(a){var c,f=!1,g=!1;return a.match(d)?(a=a.replace(d,""),this.parentNode||(b.appendChild(this),g=!0),parentNode=this.parentNode,this.id||(this.id="rootedQuerySelector_id_"+(new Date).getTime(),f=!0),c=e.call(parentNode,"#"+this.id+" "+a),f&&(this.id=""),g&&b.removeChild(this),c):e.call(this,a)}}if(!HTMLElement.prototype.querySelectorAll)throw new Error("rootedQuerySelectorAll: This polyfill can only be used with browsers that support querySelectorAll");var b=document.createElement("div");try{b.querySelectorAll(":scope *")}catch(c){var d=/^\s*:scope/gi;a(HTMLElement.prototype,"querySelector"),a(HTMLElement.prototype,"querySelectorAll")}}();

--- a/gruntfile.js
+++ b/gruntfile.js
@@ -1,10 +1,12 @@
 module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-jshint');
   grunt.loadNpmTasks('grunt-contrib-watch');
+  grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-karma');
 
   grunt.initConfig({
     pkg: grunt.file.readJSON('package.json'),
+    year: new Date().getFullYear(),
     jshint: {
       gruntfile: 'Gruntfile.js',
       tests: 'test/*.js',
@@ -30,6 +32,27 @@ module.exports = function(grunt) {
         singleRun: true
       }
     },
+    uglify:{
+        options:{
+            banner:'/* scopeQuerySelectorShim.js' + '\n*' + '\n* Copyright (C) <%= year %> Larry Davis' + '\n* All rights reserved.' + '\n*' + '\n* This software may be modified and distributed under the terms' + '\n* of the BSD license.  See the LICENSE file for details.' + '\n*/\n'
+        },
+        expanded:{
+            options:{
+                mangle:false,
+                compress:false,
+                beautify:true,
+                preserveComments:true
+            },
+            files:{
+                'dist/scopedQuerySelectorShim.js':[ 'src/scopedQuerySelectorShim.js' ]
+            }
+        },
+        minified:{
+            files:{
+                'dist/scopedQuerySelectorShim.min.js':[ 'src/scopedQuerySelectorShim.js' ]
+            }
+        }
+    },
     watchFiles: {
       gruntfile: {
         files: 'Gruntfile.js',
@@ -37,7 +60,7 @@ module.exports = function(grunt) {
       },
       src: {
         files: [ 'src/**' ],
-        tasks: [ 'jshint:src', 'karma:watch:run' ]
+        tasks: [ 'jshint:src', 'uglify', 'karma:watch:run' ]
       },
       unitTests: {
         files: [ 'test/*.js' ],

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "grunt": "~0.4.1",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-contrib-jshint": "~0.7.2",
+    "grunt-contrib-uglify": "~0.9.1",
     "grunt-karma": "~0.6.2",
     "karma": "~0.10.5",
     "karma-firefox-launcher": "~0.1.0",


### PR DESCRIPTION
new grunt uglify task builds a beautified version of the shim along
with a minified version in a new dist/ directory and adds the `LICENSE`
header to each

grunt uglify is triggered by `grunt watchFiles:src`
consider: `cachebusting dist/*.js` file names with a version number ie:
`dist/scopedQuerySelectorShim.1.0.0.min.js`

Assuming #6 is merged we'll be able to ignore `"src"` in `bower.json` so that only the new `dist` directory is fetched. Could also probably ignore the `LICENSE` as it will be prepended to `dist/*.js`
